### PR TITLE
add redis and db dependency for running rails server/worker

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,9 @@ services:
       - "2358:2358"
       - "3001:3001" # For ./scripts/dev/serve-docs
     privileged: true
+    depends_on:
+      - db
+      - redis
 
   db:
     image: postgres:13.0

--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -42,6 +42,9 @@ services:
     privileged: true
     <<: *default-logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   workers:
     image: judge0/judge0:latest
@@ -51,6 +54,9 @@ services:
     privileged: true
     <<: *default-logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   db:
     image: postgres:13.0

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -17,6 +17,9 @@ services:
     privileged: true
     <<: *default-logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   db:
     image: postgres:13.0

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -33,6 +33,9 @@ services:
     privileged: true
     <<: *logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   workers:
     image: judge0/judge0:latest
@@ -44,6 +47,9 @@ services:
     privileged: true
     <<: *logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   db:
     image: postgres:13.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     privileged: true
     <<: *default-logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   workers:
     image: judge0/judge0:latest
@@ -26,6 +29,9 @@ services:
     privileged: true
     <<: *default-logging
     restart: always
+    depends_on:
+      - db
+      - redis
 
   db:
     image: postgres:13.0


### PR DESCRIPTION
This will help fix following errors when the containers are brought up by running `docker-compose up`
- Redis::CannotConnectError: Error connecting to Redis on redis:6379 (Errno::ECONNREFUSED)
- IO::EINPROGRESSWaitWritable: Operation now in progress - connect(2) would block