### PR TITLE
fix: math.h sqrt() doesn't work with declared variable in c language

### DIFF
--- a/db/languages/active.rb
+++ b/db/languages/active.rb
@@ -59,7 +59,7 @@
     name: "C (GCC 9.2.0)",
     is_archived: false,
     source_file: "main.c",
-    compile_cmd: "/usr/local/gcc-9.2.0/bin/gcc %s main.c",
+    compile_cmd: "/usr/local/gcc-9.2.0/bin/gcc %s main.c -lm",
     run_cmd: "./a.out"
   },
   {


### PR DESCRIPTION
Fix of this issue: https://github.com/judge0/judge0/issues/431