### PR TITLE
POSTGRES password was not set gives error while setting up so updated…

### DIFF
--- a/judge0.conf
+++ b/judge0.conf
@@ -231,7 +231,7 @@ POSTGRES_USER=judge0
 
 # Password of the user. Cannot be blank. Used only in production.
 # Default: NO DEFAULT, YOU MUST SET YOUR PASSWORD
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=admin
 
 
 ################################################################################


### PR DESCRIPTION
… it to admin as the default password

I was trying to use Judge 0 on docker and have set it up using docker-compose but what I saw was server 1 and db 1 are stuck in a restarting loop. When I took logs of it, it said the password was not set in an environment variable we can make a default password as admin so others will not face the same issue. I know it already commented that the user should set it before use but it's not relevant as everyone doesn't have that much time to read these details.