### PR TITLE
Replace db:create + db:migrate + db:seed with db:prepare

### DIFF
--- a/scripts/server
+++ b/scripts/server
@@ -9,7 +9,7 @@ export | sudo tee /api/environment
 for i in $(seq 1 $RESTART_MAX_TRIES); do
     [[ -f tmp/pids/server.pid ]] && rm -f tmp/pids/server.pid
 
-    rails db:create db:migrate db:seed
+    rails db:prepare
     rails s -b 0.0.0.0
     [[ $? -eq 0 ]] && break
     sleep 2s


### PR DESCRIPTION
Currently, server startup fails if the application's database user doesn't have permission to create databases. This change avoids that issue by using `db:prepare`, which automatically handles setup without attempting to create the database if it already exists.

Rails `db:prepare` task implementation:
https://github.com/rails/rails/blob/v6.1.7.10/activerecord/lib/active_record/railties/databases.rake#L355-L387