### PR TITLE
Refactor argument sanitization and implement secure file creation

### DIFF
--- a/app/services/command_arguments.rb
+++ b/app/services/command_arguments.rb
@@ -1,0 +1,11 @@
+module CommandArguments
+  DANGEROUS_CHARS = /[$&;<>|`\\\n\r]/
+
+  def self.sanitize(args)
+    args
+      .to_s
+      .encode("UTF-8", invalid: :replace, undef: :replace, replace: '')
+      .strip
+      .gsub(DANGEROUS_CHARS, "")
+  end
+end

--- a/spec/services/command_arguments_spec.rb
+++ b/spec/services/command_arguments_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CommandArguments do
+  describe '.sanitize' do
+    it 'strips leading and trailing whitespace' do
+      expect(described_class.sanitize("  --hello  ")).to eq("--hello")
+    end
+
+    it 'removes dangerous characters' do
+      dangerous = "$&;<>|`\\\n\r"
+      dangerous.chars.each do |char|
+        input = "--a#{char}b"
+        expect(described_class.sanitize(input)).to eq("--ab")
+      end
+    end
+
+    it 'replaces invalid UTF-8 sequences with replacement character' do
+      invalid_utf8 = "valid\xFFinvalid".force_encoding("UTF-8")
+      expect(described_class.sanitize(invalid_utf8)).to eq("validinvalid")
+    end
+
+    it 'returns an empty string when given nil' do
+      expect(described_class.sanitize(nil)).to eq("")
+    end
+
+    it 'does not remove safe characters' do
+      safe_string = "--abc123_-./ -option  -I../a/b"
+      expect(described_class.sanitize(safe_string)).to eq(safe_string)
+    end
+  end
+end


### PR DESCRIPTION
Improve argument filtering to block dangerous shell characters like `\n` and `\`, and use no-follow flags when creating files to prevent symlink attacks, mitigating arbitrary file write vulnerabilities.

Inspired by:
https://tantosec.com/blog/judge0/
