### PR TITLE
Docs: Improve docker-compose.yml with comment for x-logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,8 @@
+# This 'x-logging' block defines a reusable logging configuration.
+# It uses a YAML anchor (&default-logging) so that all services
+# (which use '<<: *default-logging') can share the same settings
+# without repeating the same code.
+
 x-logging:
   &default-logging
   logging:


### PR DESCRIPTION
Adds a helpful comment to explain the 'x-logging' YAML anchor, making the file easier to understand for new contributors.