### PR TITLE
feat: cgroupv2 / isolate v2 sandbox compatibility

### DIFF
--- a/app/jobs/isolate_job.rb
+++ b/app/jobs/isolate_job.rb
@@ -92,7 +92,7 @@ class IsolateJob < ApplicationJob
     -w 4 \
     -k #{Config::MAX_STACK_LIMIT} \
     -p#{Config::MAX_MAX_PROCESSES_AND_OR_THREADS} \
-    #{submission.enable_per_process_and_thread_time_limit ? (cgroups.present? ? "--no-cg-timing" : "") : "--cg-timing"} \
+    -n 512 \
     #{submission.enable_per_process_and_thread_memory_limit ? "-m " : "--cg-mem="}#{Config::MAX_MEMORY_LIMIT} \
     -f #{Config::MAX_EXTRACT_SIZE} \
     --run \
@@ -149,7 +149,7 @@ class IsolateJob < ApplicationJob
     -w #{Config::MAX_WALL_TIME_LIMIT} \
     -k #{Config::MAX_STACK_LIMIT} \
     -p#{Config::MAX_MAX_PROCESSES_AND_OR_THREADS} \
-    #{submission.enable_per_process_and_thread_time_limit ? (cgroups.present? ? "--no-cg-timing" : "") : "--cg-timing"} \
+    -n 512 \
     #{submission.enable_per_process_and_thread_memory_limit ? "-m " : "--cg-mem="}#{Config::MAX_MEMORY_LIMIT} \
     -f #{Config::MAX_MAX_FILE_SIZE} \
     -E HOME=/tmp \
@@ -230,7 +230,7 @@ class IsolateJob < ApplicationJob
     -w #{submission.wall_time_limit} \
     -k #{submission.stack_limit} \
     -p#{submission.max_processes_and_or_threads} \
-    #{submission.enable_per_process_and_thread_time_limit ? (cgroups.present? ? "--no-cg-timing" : "") : "--cg-timing"} \
+    -n 512 \
     #{submission.enable_per_process_and_thread_memory_limit ? "-m " : "--cg-mem="}#{submission.memory_limit} \
     -f #{submission.max_file_size} \
     -E HOME=/tmp \
@@ -264,7 +264,13 @@ class IsolateJob < ApplicationJob
 
     submission.time = metadata[:time]
     submission.wall_time = metadata[:"time-wall"]
-    submission.memory = (cgroups.present? ? metadata[:"cg-mem"] : metadata[:"max-rss"])
+    # isolate v2 reads memory peak from cgroupv2's memory.peak (kernel 5.19+).
+    # On older kernels (e.g. AKS Ubuntu 22.04 still ships kernel 5.15)
+    # memory.peak does not exist, so isolate silently omits the cg-mem line
+    # from metadata and submission.memory ends up as 0 for every submission.
+    # Fall back to max-rss (always emitted via getrusage) so MLE detection
+    # keeps working until the host kernel is new enough.
+    submission.memory = (cgroups.present? ? (metadata[:"cg-mem"] || metadata[:"max-rss"]) : metadata[:"max-rss"])
     submission.stdout = program_stdout
     submission.stderr = program_stderr
     submission.exit_code = metadata[:exitcode].try(:to_i) || 0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,27 @@
 #!/bin/bash
+set -e
+
+# cgroupv2 delegation setup — required by isolate v2.
+# Idempotent: safe to run on every container start. The host must mount the
+# unified cgroupv2 hierarchy at /sys/fs/cgroup (Docker / Kubernetes do this
+# automatically on cgroupv2 hosts). On cgroupv1 hosts the controllers file
+# below is absent, so the entire block is skipped.
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    sudo mkdir -p /sys/fs/cgroup/init
+    echo $$ | sudo tee /sys/fs/cgroup/init/cgroup.procs >/dev/null 2>&1 || true
+    for c in cpu memory pids io cpuset; do
+        if grep -qw "$c" /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
+            echo "+$c" | sudo tee /sys/fs/cgroup/cgroup.subtree_control >/dev/null 2>&1 || true
+        fi
+    done
+    sudo mkdir -p /sys/fs/cgroup/isolate
+    for c in cpu memory pids io cpuset; do
+        if grep -qw "$c" /sys/fs/cgroup/isolate/cgroup.controllers 2>/dev/null; then
+            echo "+$c" | sudo tee /sys/fs/cgroup/isolate/cgroup.subtree_control >/dev/null 2>&1 || true
+        fi
+    done
+    sudo mkdir -p /run/isolate/locks
+fi
+
 sudo cron
 exec "$@"


### PR DESCRIPTION
## Summary

Adapts Judge0's sandbox invocation and container startup to work with [ioi/isolate v2.x](https://github.com/ioi/isolate), which is cgroupv2-only since v2.0. Required when running Judge0 on hosts where cgroupv1 is no longer mounted — AKS Ubuntu 22.04, RHEL 9, Fedora 39+, modern Ubuntu LTS, etc.

This is the consumer-side companion to **judge0/compilers#29**, which swaps the sandbox binary from `judge0/isolate@ad39cc4` (cgroupv1-only fork) → `ioi/isolate v2.6` in the compilers image.

## Changes

### `docker-entrypoint.sh`

Adds a cgroupv2 delegation block at startup. The whole block is gated on `/sys/fs/cgroup/cgroup.controllers` existing — on cgroupv1 hosts it's a no-op, so existing deployments are unaffected.

- Moves PID 1 into `/sys/fs/cgroup/init` so `/sys/fs/cgroup` itself can have its `cgroup.subtree_control` written (cgroupv2 forbids both having processes and enabling controllers on the same cgroup).
- Enables `cpu memory pids io cpuset` controllers on the root subtree.
- Creates `/sys/fs/cgroup/isolate` (isolate's default `cg_root`) and enables the same controllers there.
- Pre-creates `/run/isolate/locks` (where isolate v2 takes its sandbox locks).
- Idempotent — safe to run on every container start.

### `app/jobs/isolate_job.rb`

- **Drop `--cg-timing` / `--no-cg-timing` flags.** Removed in isolate v2.0; cgroup-based timing is always-on in `--cg` mode now. Passing the flag is silently ignored on v2 today, but better to clean it up.
- **Add `-n 512` open-files cap** to all three isolate invocations (unzip, compile, run). Upstream isolate v2 defaults to `-n 64`, which is too tight for Go's compiler (gives ENFILE errors); the old `judge0/isolate` fork hard-coded 512 internally so existing submissions don't expect the lower cap.
- **Memory metric fallback.** isolate v2 reads memory peak from cgroupv2's `memory.peak`, which requires kernel ≥ 5.19. Several long-lived distros still ship older kernels — AKS Ubuntu 22.04 is on 5.15 today — where `memory.peak` does not exist. isolate's `cg_read("?memory.peak", val)` returns false there and the `if (mem) meta_printf(...)` guard skips emitting the `cg-mem` line, so `metadata[:cg-mem]` returns nil and `submission.memory` ends up `0` for every submission.

  Fix: use `metadata[:cg-mem] || metadata[:max-rss]` when `cgroups.present?`. `max-rss` comes from `getrusage` and is always emitted. Once nodes move to a 5.19+ kernel `cg-mem` resumes automatically. Behaviour is unchanged when running with `--no-cg` (where `cg-mem` was never available anyway).

## Verification

- Built on Debian Bookworm against [judge0/compilers#29](https://github.com/judge0/compilers/pull/29) (isolate v2.6).
- Deployed to production at `compiler.talview.com` (Talview's Judge0 instance) on the standard platform AKS nodepool (cgroupv2, kernel 5.15). 9-language smoke test after deploy: 9/9 Accepted, memory metric populated via the max-rss fallback (~88 MB for a 2M-int Python script, as expected).
- No cgroupv1 hosts regressed because the entrypoint block is gated and the isolate flags swap is no-op there.

## Backwards compatibility

- **cgroupv1 hosts:** entrypoint block is skipped. `-n 512` was implicit before. `--cg-timing` removal: the old `judge0/isolate` fork already ignored both flags as a no-op in non-cg mode, and the production effect is identical.
- **kernel 5.19+ hosts:** behaviour matches current — `cg-mem` is present, `||` short-circuits, max-rss path is dead code.
- **Older kernels on cgroupv2:** previously `submission.memory == 0`; now max-rss.

## Linked

- Compilers PR: **judge0/compilers#29** (bookworm base + compiler version refresh + isolate v2.6)
- Talview tracking: [SRE-3142](https://linear.app/talview/issue/SRE-3142), [SRE-3160](https://linear.app/talview/issue/SRE-3160)